### PR TITLE
Impossible to properly set SESSION_SECRET using enviroment variables

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 // Defaults:
 var PORT = process.env.PORT || 3000
-  , SESSION_SECRET = process.env.PORT || "8L8BudMkqBUqrz"
+  , SESSION_SECRET = process.env.SESSION_SECRET || "8L8BudMkqBUqrz"
   , SERVER_NAME = process.env.SERVER_NAME || "http://localhost:3000"
   , GITHUB_APP_ID = process.env.GITHUB_APP_ID || "a3af4568e9d8ca4165fe"
   , GITHUB_APP_SECRET = process.env.GITHUB_APP_SECRET || "18651128b57787a3336094e2ba1af240dfe44f6c"


### PR DESCRIPTION
As can be seen in lib/config.js SESSION_SECRET is assigned the value of process.env.PORT or otherwise a default. I would assume this is a mistake, and it is supposed to read process.env.SESSION_SECRET
