### PR TITLE
bugfix

### DIFF
--- a/routes/api/jobs.js
+++ b/routes/api/jobs.js
@@ -242,6 +242,8 @@ exports.jobs = function(req, res) {
 
         });
         l.sort(function(a, b) {
+          if (!a.finished_timestamp || !a.finished_timestamp.getTime) return true;
+          if (!b.finished_timestamp || !b.finished_timestamp.getTime) return false;
           return a.finished_timestamp.getTime() < b.finished_timestamp.getTime();
         });
         // look at l


### PR DESCRIPTION
ooh badnews; I broke it. Here's the fix.

```
2013-07-14T05:11:24.127437+00:00 app[web.1]: TypeError: Cannot call method 'getTime' of undefined
2013-07-14T05:11:24.127437+00:00 app[web.1]:     at /app/routes/api/jobs.js:245:72
2013-07-14T05:11:24.127437+00:00 app[web.1]:     at Promise.<anonymous> (/app/node_modules/step/lib/step.js:116:22)
2013-07-14T05:11:24.127437+00:00 app[web.1]:     at next (/app/node_modules/step/lib/step.js:51:23)
2013-07-14T05:11:24.127437+00:00 app[web.1]:     at /app/node_modules/step/lib/step.js:83:14
2013-07-14T05:11:24.127627+00:00 app[web.1]:     at Promise.emit (/app/node_modules/mongoose/node_modules/mpromise/lib/promise.js:79:38)
```
