### PR TITLE
enabled CORS, set it as a configuration options, disabled by default

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -77,8 +77,8 @@ var init = exports.init = function (config) {
     app.engine('jade', require('jade').__express);
     app.engine('html', pluginTemplates.engine);
 
-    if (config.enable_cors) {
-      app.use(cors(config));
+    if (config.cors) {
+      app.use(cors(config.cors));
     }
 
     app.use(middleware.bodySetter);

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,16 +1,15 @@
 module.exports = cors;
 
-function cors(config) {
+function cors(domains) {
 
-  var allowedDomains = config.cors_allowed_domains;
-  if (Array.isArray(allowedDomains)) {
-    allowedDomains = allowedDomains.join(',');
+  if (Array.isArray(domains)) {
+    domains = domains.join(',');
   }
 
   return CORS;
 
   function CORS(req, res, next) {
-    res.setHeader('Access-Control-Allow-Origin', allowedDomains);
+    res.setHeader('Access-Control-Allow-Origin', domains);
     res.setHeader('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Cookie');
     res.setHeader('Access-Control-Allow-Credentials', 'true');

--- a/lib/libconfig.js
+++ b/lib/libconfig.js
@@ -23,8 +23,7 @@ var envDefaults = {
   , github_app_id : ''
   , github_secret : ''
 
-  , enable_cors : false
-  , cors_allowed_domains: '*'
+  , cors : false
 
 }
 envDefaults.server_name = envDefaults.server_name + ":" + envDefaults.port


### PR DESCRIPTION
This pull request enables Strider users to use CORS if they choose to by explicitly enabling this feature, passing in the new configuration options:
- `enable_cors` - `false` by default
- `cors_allowed_domains`: `*` by default

I'm using Strider as a remote service from the browser. For this to work I have to enable CORS.
To enable CORS I needed to monkey-patch the middleware stack and stick a custom middleware that sets the right headers before any other middleware happens. Having this pull-request accepted means that I no longer have to do that.
