### PR TITLE
get project API

### DIFF
--- a/routes/jobs/index.js
+++ b/routes/jobs/index.js
@@ -79,21 +79,25 @@ function html(req, res) {
       })
     })
 
-    var data = {
-      project: sanitized,
-      accessLevel: req.accessLevel,
-      jobs: jobs,
-      job: job,
-      statusBlocks: common.statusBlocks,
-      showStatus: showStatus,
-      page_base: req.params.org + '/' + req.params.repo
-    }
     res.format({
       html: function() {
-        res.render('build.html', data)
+        res.render('build.html', {
+          project: sanitized,
+          accessLevel: req.accessLevel,
+          jobs: jobs,
+          job: job,
+          statusBlocks: common.statusBlocks,
+          showStatus: showStatus,
+          page_base: req.params.org + '/' + req.params.repo
+        })
       },
       json: function() {
-        res.send(data);
+        res.send({
+          project: sanitized,
+          accessLevel: req.accessLevel,
+          jobs: jobs,
+          job: job
+        })
       }
     })
 


### PR DESCRIPTION
I need a remote API for fetching a project for a given repo that I can use in the browser directly.

This pull-request introduces a new API end-point `GET /:org/:repo/project`.

This is not the most gracious implementation, since I have to obtain the project access_level for the given current user..

The only way I found was to clone the project document and inject the `access_level` attribute computed on the `middleware.project` middleware.
