### PR TITLE
Repo get config API also responds JSON

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -305,11 +305,9 @@ exports.config = function(req, res) {
   function respond(data) {
     res.format({
       html: function() {
-        console.log('HTML');
         res.render('project_config.html', data)
       },
       json: function() {
-        console.log('JSON');
         res.send(data);
       }
     });


### PR DESCRIPTION
The `GET /:org/:repo/config` endpoint responded by rendering HTML.

This pull-request maintains that, but adds the JSON format to make it also available as a JSON API.

(This uses content-negotiation, and it can perhaps later be generalised into a generic responding internal API as needed.)
