### PR TITLE
GET /session to reply the entire user object

### DIFF
--- a/routes/api/session.js
+++ b/routes/api/session.js
@@ -26,5 +26,5 @@ exports.create = function createSession(req, res, next) {
  * Get current session, containing user id
  */
 exports.get = function getSession(req, res, next) {
-  res.send({user: req.session.passport.user});
+  res.send({user: req.user});
 };


### PR DESCRIPTION
When dealing with user setup logic, we need the user accounts on the browser side.

This PR makes the GET /api/session route to reply the entire user object.
