### PR TITLE
fix for Cannot call method 'getTime' of null

### DIFF
--- a/lib/backchannel.js
+++ b/lib/backchannel.js
@@ -155,7 +155,11 @@ BackChannel.prototype = {
       if (err) return console.error('Error finding job', err.message)
       if (!job) return console.error('job.done but job not found:', data.id)
       _.extend(job, data)
-      job.duration = data.finished.getTime() - data.started.getTime()
+      try {
+        job.duration = data.finished.getTime() - data.started.getTime()
+      } catch (ignore) {
+        job.duration = 1
+      }
       job.markModified('phases')
       job.markModified('plugin_data')
       job.test_exitcode = job.phases.test && job.phases.test.exitCode


### PR DESCRIPTION
Fixed this error, when I had some unfinished jobs due errors in filesystem 
/opt/node-0.10.21/lib/node_modules/strider/node_modules/mongoose/lib/utils.js:419
        throw err;
              ^
TypeError: Cannot call method 'getTime' of null
    at Promise.<anonymous> (/opt/node-0.10.21/lib/node_modules/strider/lib/backchannel.js:158:61)
