### PR TITLE
Allow DB_URI to shortcut MONGODB_URI

### DIFF
--- a/docker/start-strider.sh
+++ b/docker/start-strider.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 env
-if [ -z "$MONGODB_URI" ]; then
+if [ -n "$DB_URI" ]; then
+  MONGODB_URI=${DB_URI}
+elif [ -z "$MONGODB_URI" ]; then
   MONGODB_URI=mongodb://localhost/strider-foss
 fi
 if [ -n "$MONGO_PORT" ]; then


### PR DESCRIPTION
In the FrozenRidge blog post that runs readers through setting up the StriderCD
Trusted Build, as well as in the configuration instructions in strider's README
(https://github.com/Strider-CD/strider#configuring), users are instructed to use
the DB_URI variable to set a custom mongodb:// connection string. The shell
script that starts strider, however, only looks for MONGODB_URI.
