### PR TITLE
Updates strider-simple-runner to ~0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "everypaas": "0.0.x",
     "pw": "0.0.4",
     "strider-extension-loader": "~0.4.1",
-    "strider-simple-runner": "~0.11.2",
+    "strider-simple-runner": "~0.11.3",
     "strider-env": "~0.4.0",
     "strider-python": "~0.2.0",
     "strider-custom": "~0.5.0",


### PR DESCRIPTION
As discussed in #357, @niallo discovered the solution to a crash in `dirkeeper` and updated `strider-simple-runner` to fix it.

After encountering the issue once again, I noticed that `strider` 38b95fb3584dc27afc09f3fe59698bdde128b631 has not yet updated this dependency.

After updating `strider-simple-runner` to `~0.11.3`, the crash was again resolved. Any reason not to bump this in **master**?
