### PR TITLE
Prevent word breaks in columns on build page

### DIFF
--- a/public/stylesheets/less/strider.less
+++ b/public/stylesheets/less/strider.less
@@ -140,8 +140,14 @@ body{
     }
     */
   }
+  .job-link {
+    min-width: 72px;
+  }
   .commit-url {
     width: auto;
+  }
+  .finished-at {
+    min-width: 80px;
   }
 }
 


### PR DESCRIPTION
These limits should allow the job link and finished at time column contents to always fit on a single line. Which looks slightly nicer.
