### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright 2012 BeyondFog, Inc
-Copyright 2013 FrozenRidge, LLC
+Copyright 2012-2014 BeyondFog, Inc
+Copyright 2013-2014 FrozenRidge, LLC
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
