### PR TITLE
Fixing saving of project public visibility

### DIFF
--- a/public/javascripts/pages/config.js
+++ b/public/javascripts/pages/config.js
@@ -480,7 +480,7 @@
         url: '/' + $scope.project.name + '/config',
         type: 'PUT',
         data: JSON.stringify({
-          public: $scope.project.public
+          public: !$scope.project.public
         }),
         contentType: 'application/json',
         success: function(data, ts, xhr) {


### PR DESCRIPTION
In the master branch, the codes saves the current project public visibility setting instead of the inverse, which is what needs to be changed.

If you'd like a video or screenshots (read the contributing guidelines but this is a small change) please let me know and I'll get it up here soon.
