### PR TITLE
Fixed an issue with Forgot Password not setting From correctly.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -110,8 +110,9 @@ var init = exports.init = function (config) {
       var forgot = require('express-forgot-password')({
           db: mongoose
         , user: models.User
-        , mailConfig : config.smtp
-        , resetMailContent : function(user, token){
+        , mailConfig: config.smtp
+        , mailFrom: config.smtp.from
+        , resetMailContent: function(user, token){
           return "Hi, To reset password for strider go to \n" + config.server_name + token + "\nthanks!" }
 
       })


### PR DESCRIPTION
`SMTP_FROM` env variable was never used in the recover password flow making Mailgun fail gloriously.  Also adjusted coding style for the colon right above/below.
