### PR TITLE
Show the icon of the appropriate provider

### DIFF
--- a/views/build.html
+++ b/views/build.html
@@ -43,7 +43,7 @@
           {% endif %}
           <span class='job-repo'>{{ project.display_name }}</span>
           <a href="[[ project.display_url ]]" target="_blank">
-            <i class="icon-github"></i>
+            <i class="icon-[[ project.provider.id ]]"></i>
           </a>
         </h3>
         {% pluginblock JobPagePostTitle %}{% endpluginblock %}


### PR DESCRIPTION
It would be nice to see the icon of the repo provider.

![icons](https://cloud.githubusercontent.com/assets/1451824/3073148/ca5ce1cc-e2da-11e3-83e2-b2b08d8a119f.png)
