### PR TITLE
Save correct public state when toggling checkbox in project settings

### DIFF
--- a/views/config/project.html
+++ b/views/config/project.html
@@ -13,7 +13,7 @@
     Public URL: <a href="{{ serverName }}/{{ project.name }}/"><strong>{{ serverName }}/{{ project.name }}/</strong></a>
     </p>
     <label class="checkbox">
-      <input data-test="public" type="checkbox" ng-model="project.public" ng-click="saveProject()"> Make this project public
+      <input data-test="public" type="checkbox" ng-model="project.public" ng-change="saveProject()"> Make this project public
     </label>
 
     </p>


### PR DESCRIPTION
The order of events for ng-click and the bound scope being updated
is ambiguous. This was causing the backend to be updated before the
scope had actually changed. Using ng-change instead of ng-click
ensures that the updated scope information is being sent to the backend.

Fixes #411
