### PR TITLE
Add version, remove jobs link from Admin menu

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -35,6 +35,7 @@ var Backchannel = require('./backchannel')
   , pluginTemplates = require('./pluginTemplates')
 
   , cors = require('cors')
+  , pjson = require('../package.json')
 
 var MONTH_IN_MILLISECONDS = 2629743000;
 var session_store;
@@ -166,7 +167,9 @@ var init = exports.init = function (config) {
   app.get('/admin/projects', auth.requireAdminOr401, routes_admin.projects);
   app.get('/admin/users', auth.requireAdminOr401, routes_admin.users);
   app.get('/admin/jobs', auth.requireAdminOr401, function(req, res) {
-    res.render('admin/jobs.html')
+    res.render('admin/jobs.html', {
+      version: pjson.version
+    })
   });
   app.get('/admin/make_admin', auth.requireAdminOr401, routes_admin.make_admin);
   app.post('/admin/remove_user', auth.requireAdminOr401, routes_admin.remove_user);

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -21,6 +21,7 @@ var  _ = require('underscore')
   , utils = require(BASE_PATH + 'utils')
   , users = require(BASE_PATH + 'users')
   , projects = require(BASE_PATH + 'projects')
+  , pjson = require('../../package.json')
 
 /*
  * make_invite_code()
@@ -43,7 +44,11 @@ exports.invites = function(req, res) {
       invite.consumed = humane.humaneDate(invite.consumed_timestamp)
     })
 
-    res.render('admin/invites.html', {invite_code: make_invite_code(), invite_codes:results})
+    res.render('admin/invites.html', {
+      invite_code: make_invite_code(),
+      invite_codes: results,
+      version: pjson.version
+    })
   })
 }
 
@@ -53,13 +58,14 @@ exports.invites = function(req, res) {
 
 exports.users = function(req,res) {
   User.find({}).sort({'_id': -1}).exec(function(err, users) {
-   res.render('admin/users.html',{
-     flash: req.flash('admin'),
-     users: users.map(function (user) {
-      user.created_date = humane.humaneDate(utils.timeFromId(user.id))
-      return user
-     })
-   })
+    res.render('admin/users.html', {
+      flash: req.flash('admin'),
+      version: pjson.version,
+      users: users.map(function (user) {
+        user.created_date = humane.humaneDate(utils.timeFromId(user.id))
+        return user
+      })
+    })
  })
 }
 
@@ -103,7 +109,8 @@ exports.projects = function(req,res) {
   projects.allProjects(function (err, projects) {
     if (err) return res.send(500, 'Error retrieving projects')
     res.render('admin/projects.html', {
-      projects: projects
+      projects: projects,
+      version: pjson.version
     })
   })
 }
@@ -187,19 +194,18 @@ exports.job = function(req, res) {
         var has_prod_deploy_target = false
         var admin_view = true
 
-        res.render('job.html',
-          {
-            admin_view: admin_view,
-            jobs: results,
-            results_detail: results_detail,
-            job_id:results[0].id.substr(0,8),
-            triggered_by_commit: triggered_by_commit,
-            org:org,
-            repo:repo,
-            repo_url:repo_url,
-            has_prod_deploy_target:has_prod_deploy_target
-          })
-        
+        res.render('job.html', {
+          admin_view: admin_view,
+          jobs: results,
+          results_detail: results_detail,
+          job_id: results[0].id.substr(0,8),
+          triggered_by_commit: triggered_by_commit,
+          org: org,
+          repo: repo,
+          repo_url: repo_url,
+          has_prod_deploy_target: has_prod_deploy_target,
+          version: pjson.version
+        })
       }
     }
   )

--- a/routes/index.js
+++ b/routes/index.js
@@ -36,18 +36,25 @@ exports.index = function(req, res){
   // Without it, Safari will cache the logged-in version despite logout!
   // See https://github.com/Strider-CD/strider/issues/284
   req.headers['if-none-match'] = 'no-match-for-this';
+
   if (req.session.return_to) {
     var return_to = req.session.return_to
     req.session.return_to=null
     return res.redirect(return_to)
   }
+
   var code = ""
+
   if (req.param('code') !== undefined) {
     code = req.param('code')
-    return res.render('register.html', {invite_code:code})
-  }
-  jobs.latestJobs(req.user, true, function (err, jobs) {
 
+    return res.render('register.html', {
+      invite_code:code,
+      version: pjson.version
+    });
+  }
+
+  jobs.latestJobs(req.user, true, function (err, jobs) {
     var availableProviders = Object.keys(common.userConfigs.provider).map(function(k){
       return common.userConfigs.provider[k]
     })
@@ -55,7 +62,8 @@ exports.index = function(req, res){
     res.render('index.html', {
       jobs: jobs,
       availableProviders: availableProviders,
-      flash: req.flash()
+      flash: req.flash(),
+      version: pjson.version
     })
   })
 };
@@ -67,6 +75,7 @@ exports.index = function(req, res){
 exports.account = function(req, res){
   var hosted = {}
     , providers = common.userConfigs.provider
+
   for (var id in providers) {
     if (common.extensions.provider[id].hosted) {
       hosted[id] = providers[id]
@@ -79,7 +88,8 @@ exports.account = function(req, res){
         user: utils.sanitizeUser(req.user.toJSON()),
         providers: hosted,
         userConfigs: common.userConfigs,
-        flash: req.flash('account')
+        flash: req.flash('account'),
+        version: pjson.version
       });
     },
     json: function() {
@@ -477,7 +487,8 @@ function renderProjects(refresh, req, res) {
               manualProjects: manualProjects,
               repos: repomap,
               flash: req.flash(),
-              project_types: availableProjectTypes()
+              project_types: availableProjectTypes(),
+              version: pjson.version
             });
           },
           json: function() {

--- a/routes/jobs/index.js
+++ b/routes/jobs/index.js
@@ -20,6 +20,7 @@ var  _ = require('underscore')
    , Job = models.Job
    , User = models.User
    , Project = models.Project
+   , pjson = require('../../package.json')
 
 module.exports = {
   html: html,
@@ -119,7 +120,8 @@ function html(req, res) {
             job: job,
             statusBlocks: common.statusBlocks,
             showStatus: showStatus,
-            page_base: req.params.org + '/' + req.params.repo
+            page_base: req.params.org + '/' + req.params.repo,
+            version: pjson.version
           })
         },
         json: function() {
@@ -133,7 +135,6 @@ function html(req, res) {
         }
       })
     })
-
   })
 }
 

--- a/views/base.html
+++ b/views/base.html
@@ -52,7 +52,6 @@
                       <li><a href='/admin/invites'>Invites</a></li>
                       <li><a href='/admin/users'>Users</a></li>
                       <li><a href='/admin/projects'>Projects</a></li>
-                      <li><a href='/admin/jobs'>Jobs</a></li>
                     </ul>
                 {% endif %}
               {% endif %}
@@ -95,9 +94,12 @@
     <footer>
     <p class='StriderBlock_FooterText'>
     {% pluginblock FooterText %}
-      <a href = 'https://github.com/Strider-CD/strider'>Strider-CD</a>
+      <a href="http://stridercd.com/">Strider-CD</a>
     | <a href="https://github.com/Strider-CD/strider/issues?state=open">Get Help / Report a Bug</a>
     | <a href="https://github.com/Strider-CD/strider/blob/master/README.md">Docs</a>
+    {% if version %}
+    | <a href="https://github.com/Strider-CD/strider/releases/tag/{{version}}">{{version}}</a>
+    {% endif %}
     {% if !currentUser %}
     | <a id="forgot-password-link" href="/auth/forgot">Forgot your password?</a>
     {% endif %}

--- a/views/bootstrap.html
+++ b/views/bootstrap.html
@@ -10,12 +10,11 @@
 <link rel="stylesheet" href="/stylesheets/css/responsive.css">
 <link rel="stylesheet" href="/stylesheets/css/strider.css">
 <link rel="stylesheet" href="/stylesheets/css/feedback.css">
+
 <script>
   /* Highlight the current page in the nav bar */
   $(document).ready(function() {
     $("div.navbar").find("li").removeClass("active");
     $("div.navbar").find("a[href='"+window.location.pathname+"']").parent().addClass("active");
-    
   });
-  
 </script>


### PR DESCRIPTION
Version comes from package.json, and links to
githubs release tags.

The jobs page still exists, but is no longer
in the dropdown, since it is completely broken.

![screen shot 2014-07-23 at 2 35 42 pm](https://cloud.githubusercontent.com/assets/34726/3678201/3fddf048-1298-11e4-9aca-3b4099d6940f.png)
![screen shot 2014-07-23 at 2 36 03 pm](https://cloud.githubusercontent.com/assets/34726/3678202/3fde17a8-1298-11e4-8ab6-a0d9fec2beb5.png)
