### PR TITLE
set priority for processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ run /usr/bin/mongod --smallfiles --fork --logpath /data/mongo.log --dbpath /data
 run echo 'strider:str!der\nroot:str!der' | chpasswd
 
 # start strider on run
-cmd "/usr/bin/supervisord"
+cmd ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 # 22 is ssh server
 # 3000 is strider

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -11,12 +11,14 @@ autorestart=true
 command=/usr/bin/mongod --smallfiles
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
+priority=1
 autorestart=true
 
 [program:strider]
 command=sh /usr/local/bin/start-strider.sh
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
+priority=2
 autorestart=true
 user=strider
 stopasgroup=true


### PR DESCRIPTION
```
/usr/lib/python2.7/dist-packages/supervisor/options.py:295: UserWarning: Supervisord is running as root and it is searching for its configuration file in default locations (including its current working directory); you probably want to specify a "-c" argument specifying an absolute path to a configuration file for improved security.
  'Supervisord is running as root and it is searching '
2014-08-15 16:02:26,625 CRIT Supervisor running as root (no user in config file)
2014-08-15 16:02:26,625 WARN Included extra file "/etc/supervisor/conf.d/supervisord.conf" during parsing
2014-08-15 16:02:26,640 INFO RPC interface 'supervisor' initialized
2014-08-15 16:02:26,640 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2014-08-15 16:02:26,640 INFO supervisord started with pid 6
2014-08-15 16:02:27,643 INFO spawned: 'strider' with pid 9
2014-08-15 16:02:27,644 INFO spawned: 'mongod' with pid 10
2014-08-15 16:02:27,645 INFO spawned: 'sshd' with pid 11
2014-08-15 16:02:28,904 INFO success: strider entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2014-08-15 16:02:28,904 INFO success: mongod entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2014-08-15 16:02:28,904 INFO success: sshd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2014-08-15 16:02:46,209 INFO exited: strider (exit status 1; not expected)
2014-08-15 16:02:47,211 INFO spawned: 'strider' with pid 22
2014-08-15 16:02:47,886 INFO exited: strider (exit status 1; not expected)
2014-08-15 16:02:48,888 INFO spawned: 'strider' with pid 30
2014-08-15 16:02:49,572 INFO exited: strider (exit status 1; not expected)
2014-08-15 16:02:51,575 INFO spawned: 'strider' with pid 38
2014-08-15 16:02:52,267 INFO exited: strider (exit status 1; not expected)
2014-08-15 16:02:55,270 INFO spawned: 'strider' with pid 46
2014-08-15 16:02:55,968 INFO exited: strider (exit status 1; not expected)
2014-08-15 16:02:56,969 INFO gave up: strider entered FATAL state, too many start retries too quickly
```

this patch starts `mongod` first and then `strider`
