### PR TITLE
fixes util.js to pass unit tests

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,8 +27,8 @@ function findBranch(branches, name) {
       }
     }
   })
-  return (function discreteBranch(name, branch, branches) {
-    console.debug('findBranch('+name+') wants to return '+branch.name);
+  return (function discreteBranchFn(name, branch, branches) {
+    console.log('findBranch('+name+') wants to return '+branch.name);
     if (branch.name !== name) {
       console.warn('Possibly returning unintended branch (expected '+name+' but got '+branch.name+'). attempting to locate discretely named branch '+name+' if it exists.');
       var discreteBranch = _.findWhere(branches, { name: name });


### PR DESCRIPTION
Two small fixes to util.js to make sure all unit tests can pass
1. Function named to `discreteBranchFn` to deal with an 'already defined' issue
2. `console.debug` was throwing an error so changed to `console.log`. Does this depend on the context you test it within? Is there any reason it should definitely be `console.debug` instead?
