### PR TITLE
improve wording on admin plugin manager actions

### DIFF
--- a/client/plugin-manager/controllers/plugin.js
+++ b/client/plugin-manager/controllers/plugin.js
@@ -42,16 +42,16 @@ module.exports = function($http, $timeout) {
   }
 
   this.perform = function(action, cb) {
-    this.status = 'requesting '+action
+    this.status = "Installing "+this.id;
     this.idle = false;
     return $http.put('/admin/plugins', {
       action: action,
       id: this.id
     }).success(function(data, status, headers, config) {
-      this.status = action+' in progress';
+      this.status = 'Restarting';
       $timeout(function() {
         waitForRestart(function() {
-          this.status = 'done'
+          this.status = 'Done'
           this.idle = true
           cb()
         }.bind(this))


### PR DESCRIPTION
Now it says "Installing" instead of "Requesting install"

I haven't tested a failure case yet... not sure what will happen if you have no internet at the time or GH is down or something like that. Other than that, it seems to behave well.
