### PR TITLE
Patch middleware api route

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -149,7 +149,7 @@ function projectPlugin(req, res, next) {
   // if it's just mirroring master
   if (branch.mirror_master) {
     res.status(400);
-    return res.status('Branch not individually configurable');
+    return res.send('Branch not individually configurable');
   }
 
   for (var i = 0; i < branch.plugins.length; i++) {


### PR DESCRIPTION
There was a small bug within the middleware.js file affecting all non anonymous API URLs exposed by plugins. If the query string parameter `branch` is missing, the request just terminates. For example, a plugin `my-plugin` that defines a route `helloworld`:

```
GET /:org/:repo/api/my-plugin/helloworld **will hang**
GET /:org/:repo/api/my-plugin/helloworld?branch=master **will not**
```

This was due to the use of `res.status()` method instead of `res.send()` 
