### PR TITLE
make navbar gravatars use https

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -178,5 +178,5 @@ function sanitizeProject(project) {
 function gravatarDefault(email) {
   return gravatar.url(email, {
     d: 'identicon'
-  });
+  }, true);
 }


### PR DESCRIPTION
Trying to reduce the mixed content warnings. So far I found two independent places in the code (1 backend, 1 frontend) in which gravatars are loaded. One was already https, the other changes to https in this commit. Still, gravatars loaded from the dashboard are not https and was not easy to locate their origin.