### PR TITLE
Refactored request access method to avoid using deprecated Express method.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -52,7 +52,7 @@ function requireParams(paramsList) {
     var val, i;
 
     for (i = 0; i < paramsList.length; i++) {
-      val = req.param(paramsList[i]);
+      val = req.params[paramsList[i]];
 
       if (!val) {
         errors.push('required parameter `' + paramsList[i] + '` not found.');

--- a/lib/routes/admin/index.js
+++ b/lib/routes/admin/index.js
@@ -78,7 +78,7 @@ exports.make_admin = function(req,res) {
 }
 
 exports.remove_user = function (req, res) {
-  User.findOne({email: req.param('email')}, function (err, user) {
+  User.findOne({email: req.params.email}, function (err, user) {
     if (err || !user) {
       req.flash('admin', 'Failed to find user')
       return res.redirect('/admin/users')

--- a/lib/routes/api/account.js
+++ b/lib/routes/api/account.js
@@ -63,7 +63,7 @@ exports.account_password = function(req, res)
   if (req.user !== undefined) {
     console.log("password change by " + req.user.email);
   }
-  var password = req.param('password');
+  var password = req.param.password;
 
   if (password.length < 6) {
     res.statusCode = 400;
@@ -87,7 +87,7 @@ exports.account_password = function(req, res)
  * <email> - the new email for the account.
  */
 exports.account_email = function(req, res) {
-  var newEmail = req.param('email');
+  var newEmail = req.params.email;
 
   if (!validator.isEmail(newEmail)) {
     res.statusCode = 400;

--- a/lib/routes/api/account.js
+++ b/lib/routes/api/account.js
@@ -63,7 +63,7 @@ exports.account_password = function(req, res)
   if (req.user !== undefined) {
     console.log("password change by " + req.user.email);
   }
-  var password = req.param.password;
+  var password = req.params.password;
 
   if (password.length < 6) {
     res.statusCode = 400;

--- a/lib/routes/api/branches.js
+++ b/lib/routes/api/branches.js
@@ -15,7 +15,7 @@ module.exports =
  *
  */
 function post(req, res) {
-  req.project.addBranch(req.param('name'), function (err, branch) {
+  req.project.addBranch(req.params.name, function (err, branch) {
     if (err) return res.send(500, err.message)
     res.send({ created: true, message: 'Branch added', branch: branch })
   })
@@ -28,7 +28,7 @@ function post(req, res) {
  *
  */
 function put(req, res) {
-  var branches = req.param('branches')
+  var branches = req.params.branches
     , query = { _id: req.project._id }
     , update = { '$set': { branches: branches } }
 
@@ -45,7 +45,7 @@ function put(req, res) {
  *
  */
 function del(req, res) {
-  var name = req.param('name')
+  var name = req.params.name
     , query = { _id: req.project._id }
     , update = { '$pull': { branches: { name: name } } }
 

--- a/lib/routes/api/collaborators/index.js
+++ b/lib/routes/api/collaborators/index.js
@@ -57,8 +57,8 @@ function get(req, res) {
  */
 function post(req, res) {
   var project = req.params.org + '/' + req.params.repo
-    , accessLevel = req.param('access') || 0
-    , email = req.param('email')
+    , accessLevel = req.params.access || 0
+    , email = req.param.email
   api.add(project, email, accessLevel, req.user, function (err, existed, already_invited) {
     if (err) return res.send(500, 'Failed to add collaborator: ' + err.message)
     if (existed) return res.send({created: true, message: 'Collaborator added'})
@@ -76,7 +76,7 @@ function post(req, res) {
  */
 function del(req, res) {
   var project = req.params.org + '/' + req.params.repo
-    , email = req.param('email')
+    , email = req.params.email
   if (req.project.creator.email.toLowerCase() === email.toLowerCase()) {
     return res.send(400, 'Cannot remove the project creator')
   }

--- a/lib/routes/api/collaborators/index.js
+++ b/lib/routes/api/collaborators/index.js
@@ -58,7 +58,7 @@ function get(req, res) {
 function post(req, res) {
   var project = req.params.org + '/' + req.params.repo
     , accessLevel = req.params.access || 0
-    , email = req.param.email
+    , email = req.params.email
   api.add(project, email, accessLevel, req.user, function (err, existed, already_invited) {
     if (err) return res.send(500, 'Failed to add collaborator: ' + err.message)
     if (existed) return res.send({created: true, message: 'Collaborator added'})

--- a/lib/routes/api/index.js
+++ b/lib/routes/api/index.js
@@ -19,7 +19,7 @@ module.exports = {
  * Require a request parameter is present or return a 400 response.
  */
 function require_param(key, req, res) {
-  var val = req.param(key);
+  var val = req.params[key];
   if (val === undefined) {
     res.statusCode = 400;
     var r = {

--- a/lib/routes/api/jobs.js
+++ b/lib/routes/api/jobs.js
@@ -42,7 +42,7 @@ exports.jobs_start = function(req, res) {
                 image: utils.gravatar(req.user.email)
             },
             timestamp: now,
-            source: {type: 'UI', page: req.param.page || 'unknown'}
+            source: {type: 'UI', page: req.params.page || 'unknown'}
         }
 
 

--- a/lib/routes/api/jobs.js
+++ b/lib/routes/api/jobs.js
@@ -21,9 +21,9 @@ var TEST_AND_DEPLOY = 'TEST_AND_DEPLOY';
  *  TEST_AND_DEPLOY - start a TEST_AND_DEPLOY job.
  */
 exports.jobs_start = function(req, res) {
-  var type = req.param('type') || TEST_ONLY
-    , branch = req.param('branch') || 'master'
-    , message = req.param('message')
+  var type = req.params.type || TEST_ONLY
+    , branch = req.params.branch || 'master'
+    , message = req.params.message
     , now = new Date()
     , trigger
     , job
@@ -42,7 +42,7 @@ exports.jobs_start = function(req, res) {
                 image: utils.gravatar(req.user.email)
             },
             timestamp: now,
-            source: {type: 'UI', page: req.param('page') || 'unknown'}
+            source: {type: 'UI', page: req.param.page || 'unknown'}
         }
 
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -39,7 +39,7 @@ exports.index = function(req, res){
   var code = '';
 
   if (req.params.code !== undefined) {
-    code = req.param.code
+    code = req.params.code
 
     return res.render('register.html', {
       invite_code:code,

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -38,8 +38,8 @@ exports.index = function(req, res){
 
   var code = '';
 
-  if (req.param('code') !== undefined) {
-    code = req.param('code')
+  if (req.params.code !== undefined) {
+    code = req.param.code
 
     return res.render('register.html', {
       invite_code:code,


### PR DESCRIPTION
Refactored express req.param('name') to req.params.name since the former is deprecated. 