### PR TITLE
Fix branch reordering

### DIFF
--- a/client/config/controllers/branches.js
+++ b/client/config/controllers/branches.js
@@ -66,7 +66,8 @@ function BranchesController($scope) {
     $.ajax({
       url: '/' + $scope.project.name + '/branches/',
       type: 'PUT',
-      data: { branches: list },
+      data: JSON.stringify({ branches: list }),
+      contentType: 'application/json',
       dataType: 'json',
       success: function(res, ts, xhr) {
         $scope.success(res.message, true, false)


### PR DESCRIPTION
The branch reordering endpoint is having problem recognizing the branches key in the request data. Sending the data is json instead of form data is one approach to getting these to work together.