### PR TITLE
Corporate Proxy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Internet-accessible deployment the following variables will need to be exported:
   - `HOST` - Host where strider listens, optional (defaults to 0.0.0.0).
   - `PORT` - Port that strider runs on, optional (defaults to 3000).
   - `DB_URI` - MongoDB DB URI if not localhost (you can safely use [MongoLab free plan][mongolab] - works great)
- 
+  - `HTTP_PROXY` - Proxy support, optional (defaults to null)
   - If you want email notifications, configure an SMTP server (we recommend [Mailgun] for SMTP if you need a server - free account gives 200 emails / day):
     - `SMTP_HOST` - SMTP server hostname e.g. smtp.example.com
     - `SMTP_PORT` - SMTP server port e.g. 587 (default)

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ var passport = require('passport');
 var async = require('async');
 var _ = require('lodash');
 var Loader = require('strider-extension-loader');
+var globalTunnel = require('global-tunnel');
 
 var app = require('./lib/app');
 var common = require('./lib/common');
@@ -23,7 +24,11 @@ var Job = models.Job;
 var Config = models.Config;
 
 common.extensions = {};
-
+//
+// Use globa-tunnel to provide proxy support.
+// The http_proxy environment variable will be used if the first parameter to globalTunnel.initialize is null.
+//
+globalTunnel.initialize();
 //
 // ### Register panel
 //

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "browserify-shim": "^3.8.0",
     "less": "^2.2.0",
     "mkdirp": "^0.5.0",
-    "path-to-regexp": "^1.0.2"
+    "path-to-regexp": "^1.0.2",
+    "global-tunnel": "^1.2.0"
   },
   "devDependencies": {
     "blanket": "^1.1.5",


### PR DESCRIPTION
The http_proxy environment variable will be used if the first parameter to globalTunnel.initialize is null or an empty object.