### PR TITLE
Remove duplicate jobs from collection

### DIFF
--- a/lib/routes/jobs/index.js
+++ b/lib/routes/jobs/index.js
@@ -106,6 +106,10 @@ function html(req, res, next) {
       var isGlobalAdmin = req.user && req.user.account_level > 0
         , canAdminProject = sanitized.access_level > 0 || isGlobalAdmin
 
+      jobs = _.uniq(jobs, function(job) {
+        return job._id.toString();
+      });
+
       res.format({
         html: function() {
           res.render('build.html', {


### PR DESCRIPTION
When having less than 20 jobs in the database, the currently running job is duplicated in the returned list. This fixes that by removing duplicate jobs from the list before returning them.

Fixes #352