### PR TITLE
striderJSON error API changed status to statusCode

### DIFF
--- a/lib/backchannel.js
+++ b/lib/backchannel.js
@@ -74,11 +74,11 @@ function prepareJob(emitter, job) {
 
       striderJson(provider, project, job.ref, function (err, config) {
         if (err) {
-          if (err.status === 403) {
+          if (err.status === 403 || err.statusCode === 403) {
             console.log('job.prepare - access to strider.json is forbidden, skipping config merge');
             config = {};
             jjob.fromStriderJson = false;
-          } else if (err.status === 404) {
+          } else if (err.status === 404 || err.statusCode === 404) {
             console.log('job.prepare - strider.json not found, skipping config merge');
             config = {};
             jjob.fromStriderJson = false;


### PR DESCRIPTION
Not sure if this changed recently, but builds were failing for me with 

error: job.prepare - error opening/processing project's `strider.json` file

The error object use using `statusCode` instead of `status`