### PR TITLE
fix mongoose db connection for local user without authentication

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -66,7 +66,7 @@ var init = exports.init = function (config) {
     console.error('MongoDB connection error: %s', error);
   });
 
-  session_store = new mongoStore({ db: mongoose.connection.db });
+  session_store = new mongoStore({ mongooseConnection: mongoose.connection });
 
   swig.init({
       root: config.viewpath,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "compression": "^1.2.2",
     "connect": "^2.17.3",
     "connect-flash": "^0.1.1",
-    "connect-mongo": "^0.4.2",
+    "connect-mongo": "^0.8.1",
     "connect-slashes": "0.0.11",
     "consolidate": "0.10.0",
     "cookie": "0.0.5",


### PR DESCRIPTION
Cloning the Strider repository and trying to start the project locally against a MongoDB with local user and without authentication didn’t work to date.

I updated the `connect-mongo` package and configured to user the MongoStore to use the `mongooseConnection` as configuration option passed during instantiation. 

Now you can run Strider without any complex setup. Nicer getting started experience for any interested user trying the platform :smiley: 
