### PR TITLE
bump strider-gitlab package to latest version: fix #767

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "strider-extension-loader": "^0.4.5",
     "strider-git": "^0.2.0",
     "strider-github": "^1.3.0",
-    "strider-gitlab": "^1.0.1",
+    "strider-gitlab": "^1.0.5",
     "strider-heroku": "^0.1.1",
     "strider-mailer": "^0.2.0",
     "strider-metadata": "^0.0.2",


### PR DESCRIPTION
This should fix the issue #767. The **strider-gitlab** plugin in version `1.0.5` already contains the fixes for the problems described in this issue. However, when just cloning the Strider and install the platfrom from scratch does not install the latest plugin version.