### PR TITLE
Fall back to building master w/o reference build

### DIFF
--- a/client/dashboard/controllers/dashboard.js
+++ b/client/dashboard/controllers/dashboard.js
@@ -18,16 +18,27 @@ module.exports = function ($scope, $element) {
   $('#dashboard').show();
   $scope.startDeploy = function (job) {
     $('.tooltip').hide();
-    socket.emit('deploy', job.project.name, job.ref.branch)
+    var branchToUse = determineTargetBranch(job);
+    socket.emit('deploy', job.project.name, branchToUse);
   };
   $scope.startTest = function (job) {
     $('.tooltip').hide();
-    socket.emit('test', job.project.name, job.ref.branch)
+    var branchToUse = determineTargetBranch(job);
+    socket.emit('test', job.project.name, branchToUse);
   };
   $scope.cancelJob = function (id) {
-    socket.emit('cancel', id)
+    socket.emit('cancel', id);
   };
 };
+
+/**
+ * Given a job, returns a branch name that should be used for a deployment or test action.
+ * @param {Object} job The job for which to determine the target branch.
+ * @returns {String} If a reference build is defined, returns the name of the branch of the reference build; "master" otherwise.
+ */
+function determineTargetBranch(job){
+  return job.ref ? job.ref.branch : "master";
+}
 
 function cleanJob(job) {
   delete job.phases;


### PR DESCRIPTION
> Please note that I wasn't able to test this code yet!

When no previous build exists for a project, attempt to build the master branch.
Note that there is still no guarantee that a branch by that name exists.
But no usable branch information is available at that point, so this is a
best-guess approach.

Fixes #787