### PR TITLE
Add titles to commit messages

### DIFF
--- a/lib/views/partials/_dashboard_row.html
+++ b/lib/views/partials/_dashboard_row.html
@@ -73,7 +73,7 @@
     <a href="[[ job.trigger.url ]]" target="_blank">
   {% endif %}
 
-  <span class="small-text truncate">
+  <span class="small-text truncate" title="[[ job.trigger.message ]]">
     <i class="trigger-icon fa fa-[[ triggers[job.trigger.type].icon ]]" data-toggle="tooltip" title="[[ triggers[job.trigger.type].title ]]"></i>
     [[ job.trigger.message ]]
   </span>
@@ -85,7 +85,7 @@
   </a>
   </span>
 
-  <span class="small-text" ng-switch-default>
+  <span class="small-text" ng-switch-default title="[[ job.trigger.message ]]">
     <i class="trigger-icon fa fa-[[ triggers[job.trigger.type].icon ]]" data-toggle="tooltip" title="[[ triggers[job.trigger.type].title ]]"></i>
     [[ job.trigger.message ]]
   </span>


### PR DESCRIPTION
The commit messages are often truncated way too short. This is a quick fix to get some readable information.