### PR TITLE
Fix truncation width

### DIFF
--- a/client/styles/strider.less
+++ b/client/styles/strider.less
@@ -28,7 +28,7 @@ body {
 }
 
 .truncate {
-  width: 340px;
+  width: 300px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/dist/styles/styles.css
+++ b/dist/styles/styles.css
@@ -9064,7 +9064,7 @@ body {
   display: none !important;
 }
 .truncate {
-  width: 340px;
+  width: 300px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
The commit message column in the dashboard is limited to 300px width, so the `.truncate` class shouldn't use a wider width.