### PR TITLE
Fix some style issues with past builds list

### DIFF
--- a/client/styles/strider.less
+++ b/client/styles/strider.less
@@ -53,12 +53,15 @@ body {
     }
   }
 
+  .job-detail-sidebar {
+    margin-top: -59px;
+  }
+
   #list-of-builds {
     max-height: 672px;
 
-    .truncate {
-      max-width: 110px;
-      display: block;
+    table td {
+      vertical-align: middle;
     }
 
     td.committer {
@@ -91,10 +94,48 @@ body {
     }
   }
   .job-link {
-    min-width: 73px;
+    min-width: 80px;
   }
   .commit-url {
-    width: auto;
+    max-width: 416px;
+    .truncate {
+      max-width: 110px;
+      @media (min-width: 1400px) {
+        max-width: 154px;
+      }
+      @media (min-width: 1600px) {
+        max-width: 133px;
+      }
+      @media (min-width: 2048px) {
+        max-width: 276px;
+      }
+      //display: block;
+    }
+  }
+
+  .run-time {
+    text-align: center;
+  }
+
+  .finished-at {
+    min-width: 100px;
+    text-align: center;
+    @media(max-width: 1600px){
+      min-width: 16px;
+    }
+  }
+
+  .summary-icon {
+    display: inline-block;
+    @media(min-width: 1600px){
+      display: none;
+    }
+  }
+  .summary-text {
+    display: none;
+    @media(min-width: 1600px){
+      display: inline-block;
+    }
   }
 }
 

--- a/dist/styles/styles.css
+++ b/dist/styles/styles.css
@@ -9080,12 +9080,14 @@ body {
 #build-page .job-title h3 .test-and-deploy-action {
   color: #2900ff;
 }
+#build-page .job-detail-sidebar {
+  margin-top: -59px;
+}
 #build-page #list-of-builds {
   max-height: 672px;
 }
-#build-page #list-of-builds .truncate {
-  max-width: 110px;
-  display: block;
+#build-page #list-of-builds table td {
+  vertical-align: middle;
 }
 #build-page #list-of-builds td.committer {
   padding: 0;
@@ -9116,10 +9118,56 @@ body {
   background-color: #eee;
 }
 #build-page .job-link {
-  min-width: 73px;
+  min-width: 80px;
 }
 #build-page .commit-url {
-  width: auto;
+  max-width: 416px;
+}
+#build-page .commit-url .truncate {
+  max-width: 110px;
+}
+@media (min-width: 1400px) {
+  #build-page .commit-url .truncate {
+    max-width: 154px;
+  }
+}
+@media (min-width: 1600px) {
+  #build-page .commit-url .truncate {
+    max-width: 133px;
+  }
+}
+@media (min-width: 2048px) {
+  #build-page .commit-url .truncate {
+    max-width: 276px;
+  }
+}
+#build-page .run-time {
+  text-align: center;
+}
+#build-page .finished-at {
+  min-width: 100px;
+  text-align: center;
+}
+@media (max-width: 1600px) {
+  #build-page .finished-at {
+    min-width: 16px;
+  }
+}
+#build-page .summary-icon {
+  display: inline-block;
+}
+@media (min-width: 1600px) {
+  #build-page .summary-icon {
+    display: none;
+  }
+}
+#build-page .summary-text {
+  display: none;
+}
+@media (min-width: 1600px) {
+  #build-page .summary-text {
+    display: inline-block;
+  }
 }
 .last-builds {
   border-collapse: separate;

--- a/lib/views/partials/_dashboard_row.html
+++ b/lib/views/partials/_dashboard_row.html
@@ -73,19 +73,19 @@
     <a href="[[ job.trigger.url ]]" target="_blank">
   {% endif %}
 
-  <span class="small-text truncate" title="[[ job.trigger.message ]]">
+  <span class="small-text pull-left truncate" title="[[ job.trigger.message ]]">
     <i class="trigger-icon fa fa-[[ triggers[job.trigger.type].icon ]]" data-toggle="tooltip" title="[[ triggers[job.trigger.type].title ]]"></i>
     [[ job.trigger.message ]]
   </span>
 
   {% if page === "history" %}
-    <a href="[[ job.trigger.url ]]" target="_blank">
+    <a class="pull-right" href="[[ job.trigger.url ]]" target="_blank">
       <i class="fa fa-external-link"></i>
   {% endif %}
   </a>
   </span>
 
-  <span class="small-text" ng-switch-default title="[[ job.trigger.message ]]">
+  <span class="small-text pull-left" ng-switch-default title="[[ job.trigger.message ]]">
     <i class="trigger-icon fa fa-[[ triggers[job.trigger.type].icon ]]" data-toggle="tooltip" title="[[ triggers[job.trigger.type].title ]]"></i>
     [[ job.trigger.message ]]
   </span>
@@ -111,7 +111,8 @@
   {% endif %}
 
   <span ng-switch-when="false" class="small-text" ng-hide="job.nojobs || job.status === 'submitted'">
-    <time data-toggle="tooltip" data-placement="top" datetime="[[ job.finished ]]" class="timeago"></time>
+    <time data-toggle="tooltip" data-placement="top" datetime="[[ job.finished ]]" class="timeago summary-text"></time>
+    <i class="fa fa-clock-o summary-icon" data-toggle="tooltip" data-placement="top" title="[[ job.finished ]]"></i>
   </span>
   <div ng-switch-when="true" class="progress-meter">
     <div class="progress progress-striped active progress-info">


### PR DESCRIPTION
This is a work in progress to make the **Past Builds** list more useful again, especially on large screens.

![](http://i.imgur.com/vOdoPum.png)
![](http://i.imgur.com/cocRzJP.png)
![](http://i.imgur.com/GVu1OdL.png)