### PR TITLE
Prevent crashing when 2 jobs from same project are queued simultaneously

### DIFF
--- a/lib/backchannel.js
+++ b/lib/backchannel.js
@@ -173,10 +173,12 @@ BackChannel.prototype = {
       njob.project = utils.sanitizeProject(job.project)
       self.send(name, 'job.new', [njob])
 
-      self.waiting[name].forEach(function (item) {
-        self.send.apply(self, [name].concat(item))
-      })
-
+      var waiting = self.waiting[name]
+      if(Array.isArray(waiting)) {
+        waiting.forEach(function (item) {
+          self.send.apply(self, [name].concat(item))
+        })
+      }
       delete self.waiting[name]
     });
   },


### PR DESCRIPTION
[Fixes #745]

I've been tracking this one down for a while. It was most notable when pull requests were also outstanding and being rerun on new commits.

Effectively if 2 jobs for the same project come in at once, it's possible for one to delete the `self.waiting[name]` array before the other comes in. I watched this one for a while with a try/catch on our production Strider server to verify that this block of code not executing or failing in a try block didn't prevent the rest of strider for running happily.

It seems like the least hacky way to patch the issue is to just to confirm it is an array before looping.