### PR TITLE
Fix POST project collaborator access level

### DIFF
--- a/lib/routes/api/collaborators/index.js
+++ b/lib/routes/api/collaborators/index.js
@@ -57,7 +57,7 @@ function get(req, res) {
  */
 function post(req, res) {
   var project = req.params.org + '/' + req.params.repo
-    , accessLevel = req.params.access || 0
+    , accessLevel = req.body.access || 0
     , email = req.body.email
   api.add(project, email, accessLevel, req.user, function (err, existed, already_invited) {
     if (err) return res.send(500, 'Failed to add collaborator: ' + err.message)


### PR DESCRIPTION
Fixes a part of #750

A collaborator with a specified access level can be saved correctly.