### PR TITLE
Fix base header html and add admin nav blocks

### DIFF
--- a/lib/views/base.html
+++ b/lib/views/base.html
@@ -27,14 +27,18 @@
                 {% if currentUser %}
                   <li><a href="/projects">Projects</a></li>
                   {% if currentUser.account_level > 0 %}
-                    <li class='dropdown'>
-                      <a href = '#' class='dropdown-toggle' data-toggle='dropdown'>Admin</a>
-                      <ul class='dropdown-menu'>
-                        <li><a href='/admin/invites'>Invites</a></li>
-                        <li><a href='/admin/users'>Users</a></li>
-                        <li><a href='/admin/projects'>Projects</a></li>
-                        <li><a href='/admin/plugins'>Plugins</a></li>
-                      </ul>
+                    {% pluginblock AdminNav %}
+                      <li class='dropdown'>
+                        <a href = '#' class='dropdown-toggle' data-toggle='dropdown'>Admin</a>
+                        <ul class='dropdown-menu'>
+                          <li><a href='/admin/invites'>Invites</a></li>
+                          <li><a href='/admin/users'>Users</a></li>
+                          <li><a href='/admin/projects'>Projects</a></li>
+                          <li><a href='/admin/plugins'>Plugins</a></li>
+                          {% pluginblock AdminNavExtra %}{% endpluginblock %}
+                        </ul>
+                      </li>
+                    {% endpluginblock %}
                   {% endif %}
                 {% endif %}
               </ul>


### PR DESCRIPTION
The `<li class="dropdown">` element was missing the closing `</li>` tag. I took the opportunity to sneak in some plugin blocks. ;-)