### PR TITLE
res.render throws a stack trace: doesnotexist.html

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -78,7 +78,7 @@ function custom404(req, res, next) {
   }
 
   res.statusCode = 404;
-  res.render('doesnotexist.html', 404);
+  res.render('doesnotexist.html');
 }
 
 // Create helper function to get or set the provifer config. Expects req.project


### PR DESCRIPTION
When accepting an invite code, the custom error
handler 'custom404' was getting invoked and the
browser was showing a stack trace instead of a
not found html page.

2015-08-10T04:48:35.872Z - error: TypeError: Cannot assign to read only property '_locals' of 404
	at ServerResponse.render (/noderoot/strider/node_modules/express/lib/response.js:952:16)
	at custom404 (/noderoot/strider/lib/middleware.js:81:7)
	at Layer.handle [as handle_request] (/noderoot/strider/node_m

Looking at the express source code reveals that the
second parameter of the res.render function is
expected to be an object, whereas we are passing
in a number.

Removing the incorrect parameter fixes the problem.