### PR TITLE
Crash on refreshing account on missing plugin

### DIFF
--- a/lib/routes/projects.js
+++ b/lib/routes/projects.js
@@ -8,6 +8,7 @@ var pjson = require('../../package.json');
 var router = express.Router();
 var Project = models.Project;
 var User = models.User;
+var debug = require('debug')('strider:routes');
 
 router.route('/')
   .get(function (req, res) {
@@ -75,18 +76,25 @@ function renderProjects(refresh, req, res) {
       }
 
       tasks.push(function (next) {
-        common.extensions.provider[account.provider].listRepos(account.config, function (err, repos) {
-          if (err) {
-            if (haveCache) {
-              groupRepos(account, repomap, tree, account.toJSON().cache)
+        debug('Now trying to list repos for the following provider for an account in the user model: ' + account.provider);
+
+        if (!common.extensions.provider[account.provider]) {
+          next(new Error("The plugin for " + account.provider + " could not be found. Please install the plugin from Admin > Plugins"));
+        }
+        else {
+          common.extensions.provider[account.provider].listRepos(account.config, function (err, repos) {
+            if (err) {
+              if (haveCache) {
+                groupRepos(account, repomap, tree, account.toJSON().cache);
+              }
+              return next(err);
             }
-            return next(err)
-          }
-          account.set('cache', repos)
-          groupRepos(account, repomap, tree, repos)
-          account.last_updated = new Date()
-          next()
-        })
+            account.set('cache', repos);
+            groupRepos(account, repomap, tree, repos);
+            account.last_updated = new Date();
+            next()
+          });
+        }
       })
     })
     for (var id in providers) {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "cookie": "^0.1.3",
     "cookie-parser": "^1.3.3",
     "cors": "^2.5.2",
+    "debug": "^2.2.0",
     "errorhandler": "^1.3.0",
     "eventemitter2": "0.4.14",
     "everypaas": "0.0.x",


### PR DESCRIPTION
Steps to reproduce:
Have an instance of strider with say, a
gitlab account and a github account
configured. Now for some reason, go to a
state where the gitlab plugin is not installed.

(In my case, this was a problem with the npm
cache/vboxfs/or something else -- was resolved
with doing a clean re-clone of the strider repo
and npm link with a fresh copy of the strider-github
repo --- the relevant part here being, the strider-gitlab
plugin was *NOT* installed.)

So, the Mongo DB had an account configured for gitlab,
but the plugin was not present. In such a situation,
trying to click on the "Refresh Account" on the Github
page was resulting in a crash -
TypeError: Cannot read property 'listRepos' of undefined
        on strider/lib/routes/projects.js:78
Fix:
For the moment, we are using req.flash to show the
appropriate error message.

However, in case of multiple problems in the parallel
tasks, only one of the errors is being shown in the GUI.
This is scope for enhancement.