### PR TITLE
job was aborting if strider.json file could not be retrieved

### DIFF
--- a/lib/backchannel.js
+++ b/lib/backchannel.js
@@ -83,7 +83,9 @@ function prepareJob(emitter, job) {
             config = {};
             jjob.fromStriderJson = false;
           } else {
-            return console.error('job.prepare - error opening/processing project\'s `strider.json` file: ', err);
+            console.error('job.prepare - error opening/processing project\'s `strider.json` file: ', err);
+            config = {};
+            jjob.fromStriderJson = false;
           }
         }
 


### PR DESCRIPTION
Today I downloaded strider-cd for the first time and attempting to setup a build using the default runner and basic strider-git plugin. However when testing, the build would always fail immediately and the strider server console would only print:
```
job.prepare - error opening/processing project's `strider.json` file: [Error: not implemented]
```

I traced this to the lib/backchannel.js file and noticed that the else statement on line 85 is returning and preventing the build from running. So being confused why a basic example didn't work and not knowing what to do, I copied the pattern from the if and else if statements directly above, which are also handling errors related to strider.json, and just initialized the config and unset the fromStriderJson flag.

Please review and merge.