### PR TITLE
Fix link to job shows current job. Closes #833

### DIFF
--- a/client/job-status/controllers/job.js
+++ b/client/job-status/controllers/job.js
@@ -15,7 +15,7 @@ var job = global.job;
 module.exports = function ($scope, $route, $location, $filter) {
   var params = $route.current ? $route.current.params : {}
   var project = global.project;
-  var jobid = params.id || (global.job && global.job._id);
+  var jobid = global.job && global.job._id;
   var socket = io.connect();
   var lastRoute = $route.current;
   var jobman = new BuildPage(socket, project.name, $scope.$digest.bind($scope), $scope, global.jobs, global.job);
@@ -67,7 +67,7 @@ module.exports = function ($scope, $route, $location, $filter) {
     });
   }
 
-  $scope.$on('$locationChangeSuccess', function(event) {
+  $scope.$on('$routeChangeSuccess', function(event) {
     if (global.location.pathname.match(/\/config$/)) {
       global.location = global.location;
       return;


### PR DESCRIPTION
`global.job` always returns the current job instead of the one URL, I can't find where it's being set.
`$routeChangeSuccess` trigger on initial page load compared to `$locationChangeSuccess`, so using that to perform an initial check. if we are requesting the current job, `if (jobid !== params.id) ` will skip the update.
CC @phiros