### PR TITLE
Fix heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deployment"
   ],
   "engines": {
-    "node": "> 0.8.x",
+    "node": "0.12.x",
     "npm": ">1.4.0 <3.0.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "debug": "^2.2.0",
     "errorhandler": "^1.3.0",
     "eventemitter2": "0.4.14",
-    "everypaas": "0.0.x",
+    "everypaas": "git://github.com/janruehling/everypaas.git#fixHerokuLookup",
     "express": "^4.10.6",
     "express-session": "^1.9.3",
     "extend": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "debug": "node debug bin/strider --no-cluster"
   },
   "dependencies": {
-    "md5": "^2.0.0",
     "ansi_up": "^1.3.0",
     "async": "^1.2.1",
     "bcryptjs": "^2.1.0",
@@ -84,6 +83,7 @@
     "jade": "^0.35.0",
     "lodash": "^3.9.3",
     "mailer": "^0.6.7",
+    "md5": "^2.0.0",
     "method-override": "^2.3.0",
     "moment": "^2.8.3",
     "mongoose": "3.8.*",
@@ -112,7 +112,7 @@
     "strider-heroku": "^0.1.1",
     "strider-mailer": "^0.2.0",
     "strider-metadata": "^0.0.3",
-    "strider-node": "git://github.com/janruehling/strider-node.git#fixMd5Dependency",
+    "strider-node": "^0.6.6",
     "strider-python": "^0.2.1",
     "strider-ruby": "^0.0.2",
     "strider-simple-runner": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "strider-heroku": "^0.1.1",
     "strider-mailer": "^0.2.0",
     "strider-metadata": "^0.0.3",
-    "strider-node": "^0.6.5",
+    "strider-node": "git://github.com/janruehling/strider-node.git#fixMd5Dependency",
     "strider-python": "^0.2.1",
     "strider-ruby": "^0.0.2",
     "strider-simple-runner": "^0.13.1",


### PR DESCRIPTION
There were a couple of things that made a Heroku install fail for me:

- if the node engine is defined as < 0.8.x it resolves to the latest node (4.1.2 right now) ... and that makes the build process on Heroku fail with an ELIFECYCLE error. Solved by setting node.engine to 0.12.x in package.json
- the everypaas module was broken so that Heroku wasn't detected anymore. Solved by fixing the lookup (switched from process.env.PORT to process.env.DYNO to detect Heroku) and adding my fork as a dependency. (link to pull request: https://github.com/niallo/everypaas/pull/3 )
- the strider-node module threw an error for it's MD5 dependency -- it required a version that didn't exist (> 1.1.0 ... this seems to be broken since the author of MD5 merged his repo with the md5 repo (https://github.com/pvorb/node-md5/issues/5#issuecomment-121759576)). Solved by fixing strider-node and adding my fork to package.json. (pull request: https://github.com/Strider-CD/strider-node/pull/29 )