### PR TITLE
Add strider-gitlab as dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "strider-extension-loader": "^0.4.5",
     "strider-git": "^0.2.0",
     "strider-github": "^2.1.1",
+    "strider-gitlab": "^1.1.3",
     "strider-heroku": "^0.1.1",
     "strider-mailer": "^0.2.0",
     "strider-metadata": "^0.0.3",


### PR DESCRIPTION
Since `strider-gitlab` is once again up to date and working we should include it in dependancies