### PR TITLE
Fetching `strider.json` from a Github repository is broken

### DIFF
--- a/lib/backchannel.js
+++ b/lib/backchannel.js
@@ -39,7 +39,7 @@ function striderJson(provider, project, ref, done) {
 
   var account = project.creator.account(project.provider.id, project.provider.account);
 
-  provider.getFile('strider.json', ref, account, project.provider.config, project, finished);
+  provider.getFile('strider.json', ref, account.config, project.provider.config, project, finished);
 }
 
 // Prepare the job for execution, save to database, and fire off a `job.new` event.


### PR DESCRIPTION
Fetching `strider.json` is currently broken, at least when the provider of the repository is Github.

I tracked that down to `striderJson()` in `lib/backchannel.js` not passing the credentials to `provider.getFile`. Using `account.config` instead of just `account` makes it work, and is consistent with what is done when calling other provider functions (for example the call to `provider.getBranches()` in `lib/routes/index.js`.