### PR TITLE
Redirect to /login and back from a project page

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -262,6 +262,11 @@ function project(req, res, next) {
       return next();
     }
 
+    if (!req.user) {
+      req.session.return_to = req.url;
+      return res.redirect('/login');
+    }
+
     res.status(401).send('Not authorized');
   });
 }

--- a/test/integration/login_test.js
+++ b/test/integration/login_test.js
@@ -57,6 +57,28 @@ module.exports = function (browser, callback) {
         });
     });
 
+    it('should log out', function () {
+      return browser.rel('/logout')
+        .waitForElementByClassName('login-form')
+        .isDisplayed()
+    })
+
+    it('should redirect to /login and back', function () {
+      return browser.rel('/strider-cd/test-node')
+        .url().should.eventually.include('/login')
+        .elementByName('email')
+        .type('test2@example.com')
+        .elementByName('password')
+        .type('test')
+        .elementByClassName('login-form')
+        .submit()
+        .url().should.eventually.include('/strider-cd/test-node')
+        .elementById('build-metadata')
+        .then(function (element) {
+          assert.isNotNull(element);
+        });
+    })
+
     after(function () {
       return browser.quit(function () {
         callback();


### PR DESCRIPTION
If you visit a project page directly without an active session in your browser (by clicking on a build badge in a README, for example), you'll get a 401 and an unstyled page saying nothing but "Not Authorized." I've changed `middleware.project` to instead redirect you to `/login`, give you a chance to authenticate, then redirect you back.

If you already are authenticated and don't have access to the project, the old behavior is preserved.