### PR TITLE
Allow plugins to extend or replace the LoginForm

### DIFF
--- a/lib/views/partials/loginform.html
+++ b/lib/views/partials/loginform.html
@@ -9,25 +9,23 @@
             <img src="images/logo-250x250-transp.png" style="height: 192px" />
         </div>
         <div class = "span8">
-          {% pluginblock LoginForm %}
-            <form class='login-form' action="/login" method="post">
-              <div class="form-group">
-                <label for="email"><strong>Email:</strong></label>
-                <input type="email" class="form-control span12" id="email" name="email" placeholder="test@example.com"/>
-              </div>
-              <div class="form-group">
-                <label for="password"><strong>Password:</strong></label>
-                <input type="password" class="form-control span12" id="password" name="password"  placeholder="dontl00k"/>
-              </div>
-              <div>
-                <input class="btn btn-success" type="submit" value="Log In"/>
-                {% pluginblock ExtraLoginButton %}
-                {% endpluginblock %}
-              </div>
-            </form>
-            <p><strong><a href="/register">I have an invite code.</a></strong></p>
-            <p><a id="forgot-password-link" href="/forgot">Forgot your password?</a></p>
-          {% endpluginblock %}
+          <form class='login-form' action="/login" method="post">
+            <div class="form-group">
+              <label for="email"><strong>Email:</strong></label>
+              <input type="email" class="form-control span12" id="email" name="email" placeholder="test@example.com"/>
+            </div>
+            <div class="form-group">
+              <label for="password"><strong>Password:</strong></label>
+              <input type="password" class="form-control span12" id="password" name="password"  placeholder="dontl00k"/>
+            </div>
+            <div>
+              <input class="btn btn-success" type="submit" value="Log In"/>
+              {% pluginblock ExtraLoginButton %}
+              {% endpluginblock %}
+            </div>
+          </form>
+          <p><strong><a href="/register">I have an invite code.</a></strong></p>
+          <p><a id="forgot-password-link" href="/forgot">Forgot your password?</a></p>
         </div>
       </div>
     </div>

--- a/lib/views/partials/loginform.html
+++ b/lib/views/partials/loginform.html
@@ -4,28 +4,32 @@
       <h3>Brilliant Continuous Deployment.</h3>
       {% include "partials/_strider_copy.html" %}
 
-        <div class="row-fluid">
-            <div class="span4">
-                <img src="images/logo-250x250-transp.png" style="height: 192px" />
-            </div>
-            <div class = "span8">
-                <form class='login-form' action="/login" method="post">
-                    <div class="form-group">
-                        <label for="email"><strong>Email:</strong></label>
-                        <input type="email" class="form-control span12" id="email" name="email" placeholder="test@example.com"/>
-                    </div>
-                    <div class="form-group">
-                        <label for="password"><strong>Password:</strong></label>
-                        <input type="password" class="form-control span12" id="password" name="password"  placeholder="dontl00k"/>
-                    </div>
-                    <div>
-                        <input class="btn btn-success" type="submit" value="Log In"/>
-                    </div>
-                </form>
-                <p><strong><a href="/register">I have an invite code.</a></strong></p>
-                <p><a id="forgot-password-link" href="/forgot">Forgot your password?</a></p>
-            </div>
+      <div class="row-fluid">
+        <div class="span4">
+            <img src="images/logo-250x250-transp.png" style="height: 192px" />
+        </div>
+        <div class = "span8">
+          {% pluginblock LoginForm %}
+            <form class='login-form' action="/login" method="post">
+              <div class="form-group">
+                <label for="email"><strong>Email:</strong></label>
+                <input type="email" class="form-control span12" id="email" name="email" placeholder="test@example.com"/>
+              </div>
+              <div class="form-group">
+                <label for="password"><strong>Password:</strong></label>
+                <input type="password" class="form-control span12" id="password" name="password"  placeholder="dontl00k"/>
+              </div>
+              <div>
+                <input class="btn btn-success" type="submit" value="Log In"/>
+                {% pluginblock ExtraLoginButton %}
+                {% endpluginblock %}
+              </div>
+            </form>
+            <p><strong><a href="/register">I have an invite code.</a></strong></p>
+            <p><a id="forgot-password-link" href="/forgot">Forgot your password?</a></p>
+          {% endpluginblock %}
         </div>
       </div>
-   </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
I've added two `{% pluginblock %}` sections to the login view to allow plugins to either completely replace, or add login buttons to, the login form.

![screen shot 2016-03-28 at 9 57 20 am](https://cloud.githubusercontent.com/assets/17565/14079499/55a1dda0-f4cc-11e5-9c28-7c142bc4361f.jpeg)

![screen shot 2016-03-28 at 9 54 43 am](https://cloud.githubusercontent.com/assets/17565/14079503/5913ecc6-f4cc-11e5-99b4-100b0671db24.jpeg)


I'm currently hacking around this by [abusing `LoggedOutFillContent`](https://github.com/smashwilson/strider-github-oauth/blob/master/webapp.js#L30-L33), but that only works on `/`, not `/login`.