### PR TITLE
Use plugin name if it exists for local plugins

### DIFF
--- a/lib/routes/admin/plugins/get_plugin_list.js
+++ b/lib/routes/admin/plugins/get_plugin_list.js
@@ -37,6 +37,7 @@ module.exports = function getPluginList(cb) {
           var pkg = require(path.join(plugin.path, 'package.json'));
 
           plugins[plugin.name] = {
+            name: plugin.title || plugin.name,
             description: pkg.description,
             type: pkg.strider.type,
             latestVersion: 'unknown'


### PR DESCRIPTION
Otherwise fall back to the id

#683 added this functionality for remote plugins, but not local plugins, so they show up with nothing in the name field (see bottom plugin in image)
![image](https://cloud.githubusercontent.com/assets/7266957/15119992/785932c2-15e1-11e6-87a8-014e6ac01c22.png)

This PR uses the plugin title of the local plugin if it's provided (not currently included, but I have submitted [a PR to strider-cli](https://github.com/Strider-CD/strider-cli/pull/20) to include this).
![image](https://cloud.githubusercontent.com/assets/7266957/15120001/80a6104e-15e1-11e6-8376-c4cc378ae658.png)

If the title is not provided, it falls back to the name/id of the plugin (which is already provided, no additional PRs necessary)
![image](https://cloud.githubusercontent.com/assets/7266957/15120011/88c2f364-15e1-11e6-8e86-67a475e3e9be.png)