### PR TITLE
Fix performance issues when viewing failed builds

### DIFF
--- a/client/ansi/filters/ansi.js
+++ b/client/ansi/filters/ansi.js
@@ -5,6 +5,7 @@ var ansi_up = require('ansi_up');
 module.exports = function () {
   return function (input, plaintext) {
     if (!input) return '';
+    if (input.length > 100000) return input;
     // handle the characters for "delete line" and "move to start of line"
     var startswithcr = /^[^\n]*\r[^\n]/.test(input);
     input = input.replace(/^[^\n\r]*\u001b\[2K/gm, '')

--- a/lib/views/build.html
+++ b/lib/views/build.html
@@ -104,7 +104,7 @@
                 <div class="build-error" ng-show="job.status === 'errored' && job.error">
                   <div class="alert alert-error">
                     <i class="fa fa-exclamation-triangle"></i>
-                    [[ job.error.message ]]
+                    [[ job.error.message.substr(0,10000) ]]
                     <a href="#" class="pull-right" ng-click="toggleErrorDetails()" ng-if="job.error.stack">
                       <i class="fa fa-ellipsis-h"></i>
                     </a>


### PR DESCRIPTION
Some builds generate a lot of output when they're failing, this can freeze up browsers and make strider unusable.

Truncates error messages to 10k characters and doesn't attempt ANSI code parsing for inputs above 100k characters.