### PR TITLE
Fix ESLint usage

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -4,14 +4,16 @@
     "sourceType": "script"
   },
   "env": {
-    "node": true
+    "browser": true,
+    "commonjs": true,
+    "es6": true
   },
   "extends": "eslint:recommended",
   "rules": {
     "indent": [2, 2],
     "brace-style": [2, "1tbs"],
     "quotes": [2, "single"],
-    "no-console": 0,
+    "no-console": 1,
     "no-use-before-define": [2, "nofunc"],
     "no-underscore-dangle": 0,
     "no-constant-condition": 0,

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "chai": "^1.9.2",
     "chai-as-promised": "^4.1.0",
     "commander": ">=0.5.2",
+    "eslint": "^3.0.1",
     "expect.js": "^0.3.1",
     "jquery": "^2.1.4",
     "jshint": "^2.5.6",


### PR DESCRIPTION
Use separate .rc files for browser and node, adjust rules to reflect actual state of code.

Strider seems to aim for Node 0.10.x compatibility, so ES6 should not be allowed, neither should ES modules, which aren't used anywhere anyway.

I don't understand why `no-console` was set globally, I left it only in the browser environment.

I'm also now extending the eslint:recommended rule set.