### PR TITLE
Set default environment variables

### DIFF
--- a/bin/strider
+++ b/bin/strider
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
+process.env.CI = 'true'
+process.env.STRIDER = 'true'
+
 var cli = require('strider-cli')({
   version: require('../package.json').version,
   /*


### PR DESCRIPTION
This allows code being run by the CI server to detect that it's running inside a CI server.

The `CI` environment variable is exposed by most major CI servers, but having a vendor specific environment variable (i.e. `STRIDER`) is also common practice.

For details see issue #892