### PR TITLE
Fix: Add missing morgan dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "md5": "^2.0.0",
     "method-override": "^2.3.10",
     "mongoose": "^4.7.6",
+    "morgan": "^1.5.0",
     "morgan-debug": "^2.0.0",
     "node-rsa": "^0.4.0",
     "opencollective": "^1.0.0",


### PR DESCRIPTION
`yarn.lock` and `package.json` are out of sync. This PR fixes the most significant issue that breaks `v1.10.0` release because `morgan@1.5.0` is missing.

> npm WARN morgan-debug@2.0.0 requires a peer of morgan@1.x but none is installed. You must install peer dependencies yourself.