### PR TITLE
feat: show status on phases

### DIFF
--- a/client-ember/app/pods/organization/repository/-components/job/template.hbs
+++ b/client-ember/app/pods/organization/repository/-components/job/template.hbs
@@ -30,7 +30,7 @@ import Status from '../status';
       </div>
 
       <ul class='flex flex-wrap'>
-        {{#each-in @job.phases as |key|}}
+        {{#each-in @job.phases as |key phase|}}
           <li>
             <button
               type='button'
@@ -45,13 +45,13 @@ import Status from '../status';
               "
               {{on 'click' (fn (mut this.selectedPhase) key)}}
             >
-              {{#if (eq (get @job.phases (concat key ".exitCode")) key)}}
+              {{#if (eq phase.exitCode key)}}
                 <Icon class='text-gray-400 mr-2' @icon='circle-notch' @spin={{true}} @prefix='fas'/>
-              {{else if (gt @job.phase.exitCode 0)}}
+              {{else if (gt phase.exitCode 0)}}
                 <Icon class='text-red-500 mr-2' @icon='times-circle' @prefix='fas'/>
-              {{else if (eq (get @job.phases (concat key ".exitCode")) 0)}}
+              {{else if (eq phase.exitCode 0)}}
                 <Icon class='text-green-500 mr-2' @icon='check-circle' @prefix='fas'/>
-              {{else if (eq (get @job.phases (concat key ".exitCode")) -1)}}
+              {{else if (eq phase.exitCode -1)}}
                 <Icon class='text-gray-300 mr-2' @icon='lock' @prefix='fas'/>
               {{else}}
                 <Icon class='text-orange-500 mr-2' @icon='exclamation-triangle' @prefix='fas'/>

--- a/client-ember/app/pods/organization/repository/-components/job/template.hbs
+++ b/client-ember/app/pods/organization/repository/-components/job/template.hbs
@@ -45,8 +45,16 @@ import Status from '../status';
               "
               {{on 'click' (fn (mut this.selectedPhase) key)}}
             >
-              {{#if (eq @job.phase key)}}
+              {{#if (eq (get @job.phases (concat key ".exitCode")) key)}}
                 <Icon class='text-gray-400 mr-2' @icon='circle-notch' @spin={{true}} @prefix='fas'/>
+              {{else if (gt @job.phase.exitCode 0)}}
+                <Icon class='text-red-500 mr-2' @icon='times-circle' @prefix='fas'/>
+              {{else if (eq (get @job.phases (concat key ".exitCode")) 0)}}
+                <Icon class='text-green-500 mr-2' @icon='check-circle' @prefix='fas'/>
+              {{else if (eq (get @job.phases (concat key ".exitCode")) -1)}}
+                <Icon class='text-gray-300 mr-2' @icon='lock' @prefix='fas'/>
+              {{else}}
+                <Icon class='text-orange-500 mr-2' @icon='exclamation-triangle' @prefix='fas'/>
               {{/if}}
 
               {{key}}


### PR DESCRIPTION
Phases now show a completion status so it's easy to see what happened

<img width="1128" alt="Screen Shot 2020-04-21 at 10 36 49 PM" src="https://user-images.githubusercontent.com/34726/79934525-be046380-8420-11ea-8043-c074512438aa.png">
